### PR TITLE
docs: update copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2020 Ilixa Ltd.
+Copyright (c) 2026 New York University (Denis Pelli and the EasyEyes team)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## Summary

- update the license copyright notice to 2026
- standardize ownership as New York University (Denis Pelli and the EasyEyes team)

## Verification

- verified the commit changes only the repository license file